### PR TITLE
Copy files into gcloud folder as expected

### DIFF
--- a/redun/executors/gcp_batch.py
+++ b/redun/executors/gcp_batch.py
@@ -79,7 +79,7 @@ class GCPBatchExecutor(Executor):
         # Default task options.
         self.default_task_options: Dict[str, Any] = {
             "mount_path": config.get("mount_path", fallback="/mnt/share"),
-            "machine_type": config.get("machine_type", fallback="e2-standard-4"),
+            "machine_type": config.get("machine_type"),
             "provisioning_model": config.get("provisioning_model", fallback="standard"),
             "vcpus": config.getint("vcpus", fallback=2),
             "gpus": config.getint("gpus", fallback=0),

--- a/redun/executors/gcp_utils.py
+++ b/redun/executors/gcp_utils.py
@@ -35,7 +35,7 @@ def batch_submit(
     region: str,
     mount_buckets: List[str],
     gcs_scratch_prefix: str,
-    machine_type: str,
+    machine_type: Optional[str],
     vcpus: int,
     memory: int,
     task_count: int,

--- a/redun/executors/gcp_utils.py
+++ b/redun/executors/gcp_utils.py
@@ -1,6 +1,6 @@
 from dataclasses import dataclass
 from enum import Enum
-from functools import cache
+from functools import lru_cache
 from statistics import mean
 from typing import Dict, Iterable, List, Optional, Tuple, Union
 
@@ -250,7 +250,7 @@ class MachineType:
     gpus: int
 
 
-@cache
+@lru_cache
 def get_available_machine_types(region: str) -> List[MachineType]:
     CLOUD_INFO_API = "https://cloudinfo.seqera.io/api/v1"
     API_URL = f"{CLOUD_INFO_API}/providers/google/services/compute/regions/{region}/products"

--- a/redun/file.py
+++ b/redun/file.py
@@ -786,7 +786,11 @@ class GSFileSystem(FsspecFileSystem):
                         dest_path = os.path.dirname(dest_path.rstrip("/"))
                         if not dest_path:
                             dest_path = "."
-                return command + f"gcloud storage cp -r {quote(src_path)} {quote(dest_path)}"
+                    return command + f"gcloud storage cp -r {quote(src_path)} {quote(dest_path)}"
+                else:
+                    # dest_path is a gs path
+                    # list all files and folders and copy them to the destination
+                    return f"find {quote(src_path)} -mindepth 1 -maxdepth 1 | gcloud storage cp -r -I {quote(dest_path)}"
         elif recursive:
             raise ValueError("recursive is not supported with stdin or stdout.")
         elif src_path:


### PR DESCRIPTION
Now if the local output folder is named `OUTPUT` and the destination is `gs://BUCKET/DEST_DIR` the content of `OUTPUT` is uploaded to `gs://BUCKET/DEST_DIR` instead of adding another indirection `gs://BUCKET/DEST_DIR/OUTPUT`
